### PR TITLE
use root locale for .toLowerCase to not run into problems on computers with non-english languages

### DIFF
--- a/Common/src/main/java/de/markusbordihn/easynpc/client/pose/PoseManager.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/client/pose/PoseManager.java
@@ -73,9 +73,9 @@ public class PoseManager {
     try {
       String resourcePath =
           TEXTURE_PREFIX
-              + skinModel.name().toLowerCase()
+              + skinModel.name().toLowerCase(java.util.Locale.ROOT)
               + "/"
-              + animation.getName().replaceAll("[^a-zA-Z0-9_.-]", "").toLowerCase();
+              + animation.getName().replaceAll("[^a-zA-Z0-9_.-]", "").toLowerCase(java.util.Locale.ROOT);
       return new ResourceLocation(Constants.MOD_ID, resourcePath);
     } catch (Exception exception) {
       log.error(

--- a/Common/src/main/java/de/markusbordihn/easynpc/client/screen/configuration/actions/ActionConfigurationScreen.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/client/screen/configuration/actions/ActionConfigurationScreen.java
@@ -91,7 +91,7 @@ public class ActionConfigurationScreen<T extends ConfigurationMenu> extends Conf
       Component buttonLabel =
           TextComponent.getTranslatedConfigText(
               "add_action",
-              TextComponent.getTranslatedConfigText(actionEventType.name().toLowerCase()));
+              TextComponent.getTranslatedConfigText(actionEventType.name().toLowerCase(java.util.Locale.ROOT)));
       return new AddButton(
               left,
               top,
@@ -109,7 +109,7 @@ public class ActionConfigurationScreen<T extends ConfigurationMenu> extends Conf
       Component buttonLabel =
           TextComponent.getTranslatedConfigText(
               "edit_action",
-              TextComponent.getTranslatedConfigText(actionEventType.name().toLowerCase()));
+              TextComponent.getTranslatedConfigText(actionEventType.name().toLowerCase(java.util.Locale.ROOT)));
       return new EditButton(
               left,
               top,

--- a/Common/src/main/java/de/markusbordihn/easynpc/client/screen/configuration/model/CustomModelConfigurationScreen.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/client/screen/configuration/model/CustomModelConfigurationScreen.java
@@ -223,8 +223,8 @@ public class CustomModelConfigurationScreen<T extends ConfigurationMenu>
               !BuiltInRegistries.ENTITY_TYPE
                   .getKey(entityType)
                   .toString()
-                  .toLowerCase()
-                  .contains(this.searchFilter.toLowerCase()));
+                  .toLowerCase(java.util.Locale.ROOT)
+                  .contains(this.searchFilter.toLowerCase(java.util.Locale.ROOT)));
     }
     this.numOfEntities = entityKeys.size();
 

--- a/Common/src/main/java/de/markusbordihn/easynpc/client/screen/configuration/preset/ImportPresetConfigurationScreen.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/client/screen/configuration/preset/ImportPresetConfigurationScreen.java
@@ -108,7 +108,7 @@ public class ImportPresetConfigurationScreen<T extends ConfigurationMenu>
     this.getSkinModel();
     return resourceLocation
         .getPath()
-        .replace("preset/" + getSkinModel().toString().toLowerCase() + "/", "")
+        .replace("preset/" + getSkinModel().toString().toLowerCase(java.util.Locale.ROOT) + "/", "")
         .replace(Constants.NPC_NBT_SUFFIX, "");
   }
 

--- a/Common/src/main/java/de/markusbordihn/easynpc/client/screen/spawner/SpawnerScreen.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/client/screen/spawner/SpawnerScreen.java
@@ -336,7 +336,7 @@ public class SpawnerScreen<T extends SpawnerMenu> extends AbstractContainerScree
       Text.drawConfigString(
           guiGraphics,
           this.font,
-          SPAWNER_PREFIX + SpawnerSettingType.SPAWN_RANGE.name().toLowerCase(),
+          SPAWNER_PREFIX + SpawnerSettingType.SPAWN_RANGE.name().toLowerCase(java.util.Locale.ROOT),
           this.spawnerRangeEdit.getX() + labelOffsetX,
           this.spawnerRangeEdit.getY() + labelOffsetY);
     }
@@ -345,7 +345,7 @@ public class SpawnerScreen<T extends SpawnerMenu> extends AbstractContainerScree
       Text.drawConfigString(
           guiGraphics,
           this.font,
-          SPAWNER_PREFIX + SpawnerSettingType.DESPAWN_RANGE.name().toLowerCase(),
+          SPAWNER_PREFIX + SpawnerSettingType.DESPAWN_RANGE.name().toLowerCase(java.util.Locale.ROOT),
           this.spawnerDespawnRangeEdit.getX() + labelOffsetX,
           this.spawnerDespawnRangeEdit.getY() + labelOffsetY);
     }
@@ -354,7 +354,7 @@ public class SpawnerScreen<T extends SpawnerMenu> extends AbstractContainerScree
       Text.drawConfigString(
           guiGraphics,
           this.font,
-          SPAWNER_PREFIX + SpawnerSettingType.REQUIRED_PLAYER_RANGE.name().toLowerCase(),
+          SPAWNER_PREFIX + SpawnerSettingType.REQUIRED_PLAYER_RANGE.name().toLowerCase(java.util.Locale.ROOT),
           this.requiredPlayerRangeEdit.getX() + labelOffsetX,
           this.requiredPlayerRangeEdit.getY() + labelOffsetY);
     }
@@ -363,7 +363,7 @@ public class SpawnerScreen<T extends SpawnerMenu> extends AbstractContainerScree
       Text.drawConfigString(
           guiGraphics,
           this.font,
-          SPAWNER_PREFIX + SpawnerSettingType.DELAY.name().toLowerCase(),
+          SPAWNER_PREFIX + SpawnerSettingType.DELAY.name().toLowerCase(java.util.Locale.ROOT),
           this.delayEdit.getX() + labelOffsetX,
           this.delayEdit.getY() + labelOffsetY);
     }
@@ -372,7 +372,7 @@ public class SpawnerScreen<T extends SpawnerMenu> extends AbstractContainerScree
       Text.drawConfigString(
           guiGraphics,
           this.font,
-          SPAWNER_PREFIX + SpawnerSettingType.MAX_NEARBY_ENTITIES.name().toLowerCase(),
+          SPAWNER_PREFIX + SpawnerSettingType.MAX_NEARBY_ENTITIES.name().toLowerCase(java.util.Locale.ROOT),
           this.maxNearbyEntitiesEdit.getX() + labelOffsetX,
           this.maxNearbyEntitiesEdit.getY() + labelOffsetY);
     }
@@ -381,7 +381,7 @@ public class SpawnerScreen<T extends SpawnerMenu> extends AbstractContainerScree
       Text.drawConfigString(
           guiGraphics,
           this.font,
-          SPAWNER_PREFIX + SpawnerSettingType.SPAWN_COUNT.name().toLowerCase(),
+          SPAWNER_PREFIX + SpawnerSettingType.SPAWN_COUNT.name().toLowerCase(java.util.Locale.ROOT),
           this.spawnCountEdit.getX() + labelOffsetX,
           this.spawnCountEdit.getY() + labelOffsetY);
     }

--- a/Common/src/main/java/de/markusbordihn/easynpc/client/texture/CustomTextureManager.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/client/texture/CustomTextureManager.java
@@ -55,12 +55,12 @@ public class CustomTextureManager {
   public static Set<UUID> getCustomTextureCacheKeys(SkinModel skinModel, String searchName) {
     HashSet<UUID> hashSet = new HashSet<>();
     String skinSearchName =
-        searchName != null && !searchName.isEmpty() ? searchName.toLowerCase() : null;
+        searchName != null && !searchName.isEmpty() ? searchName.toLowerCase(java.util.Locale.ROOT) : null;
     for (TextureModelKey textureModelKey : textureCache.keySet()) {
       if (skinModel.equals(textureModelKey.getSkinModel())
           && (skinSearchName == null
               || textureModelKey.getResourceName().isEmpty()
-              || textureModelKey.getResourceName().toLowerCase().contains(skinSearchName))) {
+              || textureModelKey.getResourceName().toLowerCase(java.util.Locale.ROOT).contains(skinSearchName))) {
         hashSet.add(textureModelKey.getUUID());
       }
     }

--- a/Common/src/main/java/de/markusbordihn/easynpc/client/texture/TextureManager.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/client/texture/TextureManager.java
@@ -219,7 +219,7 @@ public class TextureManager {
   }
 
   public static String getResourceName(String name, String type) {
-    return (TEXTURE_PREFIX + type + "_" + name.replaceAll("[^a-zA-Z0-9_.-]", "")).toLowerCase();
+    return (TEXTURE_PREFIX + type + "_" + name.replaceAll("[^a-zA-Z0-9_.-]", "")).toLowerCase(java.util.Locale.ROOT);
   }
 
   public static String getFileName(UUID uuid) {

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/action/ActionDataType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/action/ActionDataType.java
@@ -54,6 +54,6 @@ public enum ActionDataType {
   }
 
   public String getId() {
-    return "actionDataType." + this.name().toLowerCase();
+    return "actionDataType." + this.name().toLowerCase(java.util.Locale.ROOT);
   }
 }

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/BaseAttributeType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/BaseAttributeType.java
@@ -28,7 +28,7 @@ public enum BaseAttributeType {
   KNOCKBACK_RESISTANCE;
 
   public String getAttributeName() {
-    return this.name().toLowerCase();
+    return this.name().toLowerCase(java.util.Locale.ROOT);
   }
 
   public String getTagName() {

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/CombatAttributeType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/CombatAttributeType.java
@@ -30,6 +30,6 @@ public enum CombatAttributeType implements EntityAttributeTypeInterface {
   }
 
   public String getAttributeName() {
-    return this.name().toLowerCase();
+    return this.name().toLowerCase(java.util.Locale.ROOT);
   }
 }

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/EntityAttribute.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/EntityAttribute.java
@@ -23,6 +23,6 @@ public enum EntityAttribute {
   SILENT;
 
   public String getAttributeName() {
-    return this.name().toLowerCase();
+    return this.name().toLowerCase(java.util.Locale.ROOT);
   }
 }

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/EnvironmentalAttributeType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/EnvironmentalAttributeType.java
@@ -31,6 +31,6 @@ public enum EnvironmentalAttributeType implements EntityAttributeTypeInterface {
   }
 
   public String getAttributeName() {
-    return this.name().toLowerCase();
+    return this.name().toLowerCase(java.util.Locale.ROOT);
   }
 }

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/InteractionAttributeType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/InteractionAttributeType.java
@@ -31,6 +31,6 @@ public enum InteractionAttributeType implements EntityAttributeTypeInterface {
   }
 
   public String getAttributeName() {
-    return this.name().toLowerCase();
+    return this.name().toLowerCase(java.util.Locale.ROOT);
   }
 }

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/MovementAttributeType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/attribute/MovementAttributeType.java
@@ -32,6 +32,6 @@ public enum MovementAttributeType implements EntityAttributeTypeInterface {
   }
 
   public String getAttributeName() {
-    return this.name().toLowerCase();
+    return this.name().toLowerCase(java.util.Locale.ROOT);
   }
 }

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/configuration/ConfigurationType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/configuration/ConfigurationType.java
@@ -95,15 +95,15 @@ public enum ConfigurationType {
   }
 
   public ResourceLocation getId() {
-    return new ResourceLocation(Constants.MOD_ID, this.name().toLowerCase() + "_configuration");
+    return new ResourceLocation(Constants.MOD_ID, this.name().toLowerCase(java.util.Locale.ROOT) + "_configuration");
   }
 
   public String getName() {
-    return this.name().toLowerCase() + "_configuration";
+    return this.name().toLowerCase(java.util.Locale.ROOT) + "_configuration";
   }
 
   public Component getConfigurationTitle(final EasyNPC<?> easyNPC) {
-    String translationKey = Constants.TEXT_CONFIG_PREFIX + this.name().toLowerCase() + ".title";
+    String translationKey = Constants.TEXT_CONFIG_PREFIX + this.name().toLowerCase(java.util.Locale.ROOT) + ".title";
     return TextComponent.getTranslatedTextRaw(
         translationKey, easyNPC.getEntity().getName().getString(16));
   }

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/dialog/DialogUtils.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/dialog/DialogUtils.java
@@ -96,9 +96,9 @@ public class DialogUtils {
       // Generate random label name
       return type
           + "_"
-          + UUID.randomUUID().toString().substring(0, 8).replace("-", "").toLowerCase();
+          + UUID.randomUUID().toString().substring(0, 8).replace("-", "").toLowerCase(java.util.Locale.ROOT);
     }
-    String label = name.trim().toLowerCase();
+    String label = name.trim().toLowerCase(java.util.Locale.ROOT);
     label = label.replace(" ", "_");
     label = label.replaceAll("[^a-z0-9_]", "");
     return label.length() > maxLength ? label.substring(0, maxLength) : label;

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/display/DisplayAttributeType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/display/DisplayAttributeType.java
@@ -43,6 +43,6 @@ public enum DisplayAttributeType {
   }
 
   public String getAttributeName() {
-    return this.name().toLowerCase();
+    return this.name().toLowerCase(java.util.Locale.ROOT);
   }
 }

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/editor/EditorType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/editor/EditorType.java
@@ -45,15 +45,15 @@ public enum EditorType {
   }
 
   public ResourceLocation getId() {
-    return new ResourceLocation(Constants.MOD_ID, this.name().toLowerCase() + "_editor");
+    return new ResourceLocation(Constants.MOD_ID, this.name().toLowerCase(java.util.Locale.ROOT) + "_editor");
   }
 
   public String getName() {
-    return this.name().toLowerCase() + "_editor";
+    return this.name().toLowerCase(java.util.Locale.ROOT) + "_editor";
   }
 
   public Component getEditorTitle(final EasyNPC<?> easyNPC) {
-    String translationKey = Constants.TEXT_CONFIG_PREFIX + this.name().toLowerCase() + ".title";
+    String translationKey = Constants.TEXT_CONFIG_PREFIX + this.name().toLowerCase(java.util.Locale.ROOT) + ".title";
     return TextComponent.getTranslatedTextRaw(
         translationKey, easyNPC.getEntity().getName().getString(20));
   }

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/objective/ObjectiveType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/objective/ObjectiveType.java
@@ -108,7 +108,7 @@ public enum ObjectiveType {
   }
 
   public String getObjectiveName() {
-    return this.name().toLowerCase();
+    return this.name().toLowerCase(java.util.Locale.ROOT);
   }
 
   public String getFriendlyName() {

--- a/Common/src/main/java/de/markusbordihn/easynpc/data/skin/SkinModel.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/data/skin/SkinModel.java
@@ -63,6 +63,6 @@ public enum SkinModel {
   }
 
   public String getName() {
-    return this.name().toLowerCase().replaceAll("[^a-zA-Z0-9/._-]", "").replace("..", "");
+    return this.name().toLowerCase(java.util.Locale.ROOT).replaceAll("[^a-zA-Z0-9/._-]", "").replace("..", "");
   }
 }

--- a/Common/src/main/java/de/markusbordihn/easynpc/io/CustomPresetDataFiles.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/io/CustomPresetDataFiles.java
@@ -126,7 +126,7 @@ public class CustomPresetDataFiles {
                                       .relativize(path)
                                       .toString()
                                       .replace("\\", "/")
-                                      .toLowerCase());
+                                      .toLowerCase(java.util.Locale.ROOT));
                       presetResourceLocationMap.put(resourceLocation, path);
                       return resourceLocation;
                     })

--- a/Common/src/main/java/de/markusbordihn/easynpc/io/WorldPresetDataFiles.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/io/WorldPresetDataFiles.java
@@ -55,7 +55,7 @@ public class WorldPresetDataFiles {
     Path presetDataFolder = getPresetDataFolder();
     String skinModelName = skinModel.name();
     if (!skinModelName.isEmpty()) {
-      Path path = presetDataFolder.resolve(skinModelName.toLowerCase());
+      Path path = presetDataFolder.resolve(skinModelName.toLowerCase(java.util.Locale.ROOT));
       if (!path.toFile().exists() && !path.toFile().mkdirs()) {
         log.error("Could not create preset model folder {}!", path);
       }
@@ -97,7 +97,7 @@ public class WorldPresetDataFiles {
                                       .relativize(path)
                                       .toString()
                                       .replace("\\", "/")
-                                      .toLowerCase());
+                                      .toLowerCase(java.util.Locale.ROOT));
                       presetResourceLocationMap.put(resourceLocation, path);
                       return resourceLocation;
                     })

--- a/Common/src/main/java/de/markusbordihn/easynpc/menu/ModMenuType.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/menu/ModMenuType.java
@@ -28,10 +28,10 @@ public enum ModMenuType {
   ;
 
   public ResourceLocation getId() {
-    return new ResourceLocation(Constants.MOD_ID, this.name().toLowerCase());
+    return new ResourceLocation(Constants.MOD_ID, this.name().toLowerCase(java.util.Locale.ROOT));
   }
 
   public String getName() {
-    return this.name().toLowerCase();
+    return this.name().toLowerCase(java.util.Locale.ROOT);
   }
 }

--- a/Common/src/main/java/de/markusbordihn/easynpc/utils/TextUtils.java
+++ b/Common/src/main/java/de/markusbordihn/easynpc/utils/TextUtils.java
@@ -40,7 +40,7 @@ public class TextUtils {
   }
 
   public static String normalizeString(String string) {
-    String normalizedString = string.toLowerCase().replace("_", " ").replace("-", " ");
+    String normalizedString = string.toLowerCase(java.util.Locale.ROOT).replace("_", " ").replace("-", " ");
     normalizedString =
         normalizedString.substring(0, 1).toUpperCase() + normalizedString.substring(1);
     return normalizedString;


### PR DESCRIPTION
Plain `.toLowerCase()` uses the current locale. This can lead to problems, for example with the turkish locale, where the lower case of an I is a small dotless ı (unicode codepoint U+0131). If this is used in a resource name, minecraft will throw an error.

This PR adds `java.util.Locale.ROOT` as a parameter to all `.toLowerCase()` calls, which fixes this problem. This way I is always transformed to a normal i.

`sh gradlew runAllGameTests` resulted in a successful build.

Note: i do not know the internals of this mod. If .toLowerCase() is used on a string that is supposed to be shown to the user, you might wanna remove the LOCALE.ROOT parameter on that call. I didn't see such a place.

Example crash message from https://gnomebot.dev/paste/254806806516203520/1317838871119265842/1317838870762623077 :
```
[15Ara2024 15:59:56.493] [modloading-worker-0/ERROR] [net.minecraftforge.fml.javafmlmod.FMLModContainer/LOADING]: Failed to create mod instance. ModID: easy_npc, class de.markusbordihn.easynpc.EasyNPC
java.lang.ExceptionInInitializerError: null
	at de.markusbordihn.easynpc.EasyNPC.<init>(EasyNPC.java:104) ~[easy_npc-forge-1.20.1-5.8.0.jar%23211!/:5.8.0]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77) ~[?:?]
	at jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:?]
	at java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499) ~[?:?]
	at java.lang.reflect.Constructor.newInstance(Constructor.java:480) ~[?:?]
	at net.minecraftforge.fml.javafmlmod.FMLModContainer.constructMod(FMLModContainer.java:77) ~[javafmllanguage-1.20.1-47.3.12.jar%23236!/:?]
	at net.minecraftforge.fml.ModContainer.lambda$buildTransitionHandler$4(ModContainer.java:124) ~[fmlcore-1.20.1-47.3.12.jar%23235!/:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.run(CompletableFuture.java:1804) ~[?:?]
	at java.util.concurrent.CompletableFuture$AsyncRun.exec(CompletableFuture.java:1796) ~[?:?]
	at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:373) ~[?:?]
	at java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1182) ~[?:?]
	at java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1655) ~[?:?]
	at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1622) ~[?:?]
	at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:165) ~[?:?]
Caused by: net.minecraft.ResourceLocationException: Non [a-z0-9/._-] character in path of location: easy_npc:ab\u0131l\u0131t\u0131es_attr\u0131bute_configuration
	at net.minecraft.resources.ResourceLocation.m_245185_(ResourceLocation.java:236) ~[client-1.20.1-20230612.114412-srg.jar%23234!/:?]
	at net.minecraft.resources.ResourceLocation.<init>(ResourceLocation.java:38) ~[client-1.20.1-20230612.114412-srg.jar%23234!/:?]
	at net.minecraftforge.registries.DeferredRegister.register(DeferredRegister.java:181) ~[forge-1.20.1-47.3.12-universal.jar%23239!/:?]
	at de.markusbordihn.easynpc.menu.ModMenuTypes.<clinit>(ModMenuTypes.java:86) ~[easy_npc-forge-1.20.1-5.8.0.jar%23211!/:5.8.0]
	... 15 more
```