### PR TITLE
Restore EasyNPC poses for EME render states

### DIFF
--- a/core/Common/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCPartAnimator.java
+++ b/core/Common/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCPartAnimator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 Markus Bordihn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package de.markusbordihn.easynpc.client.renderer.entity.easymodelentities;
+
+import de.markusbordihn.easymodelentities.api.client.EasyModelPartAnimator;
+import de.markusbordihn.easymodelentities.api.data.client.EasyModelPartTransform;
+import de.markusbordihn.easynpc.compat.easymodelentities.EasyModelEntitiesManager;
+import de.markusbordihn.easynpc.data.model.ModelPartType;
+import de.markusbordihn.easynpc.data.position.CustomPosition;
+import de.markusbordihn.easynpc.data.rotation.CustomRotation;
+import de.markusbordihn.easynpc.data.scale.CustomScale;
+import de.markusbordihn.easynpc.entity.easynpc.npc.easymodelentities.EasyModelNPC;
+import java.util.EnumMap;
+import java.util.Map;
+
+/** Creates render-thread-safe snapshots of the fixed EasyNPC model-part pose. */
+public final class EasyModelNPCPartAnimator {
+
+  private EasyModelNPCPartAnimator() {}
+
+  public static EasyModelPartAnimator snapshot(EasyModelNPC easyModelNPC) {
+    if (easyModelNPC == null || !easyModelNPC.hasChangedModel()) {
+      return EasyModelPartAnimator.NONE;
+    }
+
+    EnumMap<ModelPartType, EasyModelPartTransform> transforms =
+        new EnumMap<>(ModelPartType.class);
+    for (ModelPartType modelPartType : ModelPartType.values()) {
+      if (modelPartType == ModelPartType.UNKNOWN) {
+        continue;
+      }
+      CustomRotation rotation = easyModelNPC.getModelPartRotation(modelPartType);
+      CustomPosition position = easyModelNPC.getModelPartPosition(modelPartType);
+      CustomScale scale = easyModelNPC.getModelPartScale(modelPartType);
+      transforms.put(
+          modelPartType,
+          new EasyModelPartTransform(rotation.x(), rotation.y(), rotation.z())
+              .withOffset(position.x(), position.y(), position.z())
+              .withScale(scale.x(), scale.y(), scale.z())
+              .withVisible(easyModelNPC.getModelPartVisibility(modelPartType)));
+    }
+
+    return snapshot(transforms);
+  }
+
+  static EasyModelPartAnimator snapshot(Map<ModelPartType, EasyModelPartTransform> transforms) {
+    if (transforms == null || transforms.isEmpty()) {
+      return EasyModelPartAnimator.NONE;
+    }
+    Map<ModelPartType, EasyModelPartTransform> snapshot = Map.copyOf(transforms);
+    return context -> {
+      ModelPartType modelPartType = EasyModelEntitiesManager.getModelPartType(context.partName());
+      return snapshot.getOrDefault(modelPartType, EasyModelPartTransform.NONE);
+    };
+  }
+}

--- a/core/Common/src/test/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCPartAnimatorTest.java
+++ b/core/Common/src/test/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCPartAnimatorTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2026 Markus Bordihn
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+ * associated documentation files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge, publish, distribute,
+ * sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+ * NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package de.markusbordihn.easynpc.client.renderer.entity.easymodelentities;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import de.markusbordihn.easymodelentities.api.client.EasyModelPartAnimator;
+import de.markusbordihn.easymodelentities.api.data.client.EasyModelPartAnimationContext;
+import de.markusbordihn.easymodelentities.api.data.client.EasyModelPartTransform;
+import de.markusbordihn.easymodelentities.data.profile.ModelBodyType;
+import de.markusbordihn.easynpc.data.model.ModelPartType;
+import java.util.EnumMap;
+import org.junit.jupiter.api.Test;
+
+class EasyModelNPCPartAnimatorTest {
+
+  private static EasyModelPartAnimationContext context(String partName) {
+    return new EasyModelPartAnimationContext(
+        partName, ModelBodyType.HUMANOID, 0.0f, 0.0f, 0.0f, 0.0f, EasyModelPartTransform.NONE);
+  }
+
+  @Test
+  void returnsNoneForEmptySnapshot() {
+    assertSame(
+        EasyModelPartAnimator.NONE,
+        EasyModelNPCPartAnimator.snapshot(new EnumMap<>(ModelPartType.class)));
+  }
+
+  @Test
+  void mapsCanonicalBoneNameToSnapshottedTransform() {
+    EnumMap<ModelPartType, EasyModelPartTransform> transforms =
+        new EnumMap<>(ModelPartType.class);
+    EasyModelPartTransform expected =
+        new EasyModelPartTransform(10.0f, 20.0f, 30.0f)
+            .withOffset(1.0f, 2.0f, 3.0f)
+            .withScale(1.1f, 1.2f, 1.3f)
+            .withVisible(false);
+    transforms.put(ModelPartType.HEAD, expected);
+    EasyModelPartAnimator animator = EasyModelNPCPartAnimator.snapshot(transforms);
+
+    transforms.clear();
+
+    assertEquals(expected, animator.animate(context("head")));
+    assertEquals(EasyModelPartTransform.NONE, animator.animate(context("custom_bone")));
+  }
+}

--- a/core/Fabric/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCRenderer.java
+++ b/core/Fabric/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCRenderer.java
@@ -20,6 +20,7 @@
 package de.markusbordihn.easynpc.client.renderer.entity.easymodelentities;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import de.markusbordihn.easymodelentities.api.data.client.EasyModelEntityRenderOptions;
 import de.markusbordihn.easymodelentities.client.render.EasyModelEntityRenderBackend;
 import de.markusbordihn.easymodelentities.client.render.EasyModelEntityRenderState;
 import de.markusbordihn.easymodelentities.runtime.EasyModelAnimationState;
@@ -55,6 +56,12 @@ public class EasyModelNPCRenderer<E extends PathfinderMob>
   public void extractRenderState(
       E entity, EasyModelEntityRenderState renderState, float partialTick) {
     super.extractRenderState(entity, renderState, partialTick);
+    renderState.easyModelRenderState = null;
+    renderState.renderOptions = EasyModelEntityRenderOptions.DEFAULT;
+    renderState.animationState = EasyModelAnimationState.AUTO;
+    renderState.limbSwing = 0.0f;
+    renderState.limbSwingAmount = 0.0f;
+    renderState.airborneAmount = 0.0f;
     if (!(entity instanceof EasyModelNPC easyModelNPC)) {
       return;
     }
@@ -68,6 +75,10 @@ public class EasyModelNPCRenderer<E extends PathfinderMob>
                 renderState.easyModelRenderState =
                     EasyModelEntityRenderBackend.resolveRenderState(contract),
             () -> log.debug("No EME contract for profile: {}", profileId));
+
+    renderState.renderOptions =
+        EasyModelEntityRenderOptions.DEFAULT.withPartAnimator(
+            EasyModelNPCPartAnimator.snapshot(easyModelNPC));
 
     renderState.entityYaw =
         entity instanceof LivingEntity le

--- a/core/Forge/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCRenderer.java
+++ b/core/Forge/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCRenderer.java
@@ -20,6 +20,7 @@
 package de.markusbordihn.easynpc.client.renderer.entity.easymodelentities;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import de.markusbordihn.easymodelentities.api.data.client.EasyModelEntityRenderOptions;
 import de.markusbordihn.easymodelentities.client.render.EasyModelEntityRenderBackend;
 import de.markusbordihn.easymodelentities.client.render.EasyModelEntityRenderState;
 import de.markusbordihn.easymodelentities.runtime.EasyModelAnimationState;
@@ -55,6 +56,12 @@ public class EasyModelNPCRenderer<E extends PathfinderMob>
   public void extractRenderState(
       E entity, EasyModelEntityRenderState renderState, float partialTick) {
     super.extractRenderState(entity, renderState, partialTick);
+    renderState.easyModelRenderState = null;
+    renderState.renderOptions = EasyModelEntityRenderOptions.DEFAULT;
+    renderState.animationState = EasyModelAnimationState.AUTO;
+    renderState.limbSwing = 0.0f;
+    renderState.limbSwingAmount = 0.0f;
+    renderState.airborneAmount = 0.0f;
     if (!(entity instanceof EasyModelNPC easyModelNPC)) {
       return;
     }
@@ -68,6 +75,10 @@ public class EasyModelNPCRenderer<E extends PathfinderMob>
                 renderState.easyModelRenderState =
                     EasyModelEntityRenderBackend.resolveRenderState(contract),
             () -> log.debug("No EME contract for profile: {}", profileId));
+
+    renderState.renderOptions =
+        EasyModelEntityRenderOptions.DEFAULT.withPartAnimator(
+            EasyModelNPCPartAnimator.snapshot(easyModelNPC));
 
     renderState.entityYaw =
         entity instanceof LivingEntity le

--- a/core/NeoForge/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCRenderer.java
+++ b/core/NeoForge/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCRenderer.java
@@ -20,6 +20,7 @@
 package de.markusbordihn.easynpc.client.renderer.entity.easymodelentities;
 
 import com.mojang.blaze3d.vertex.PoseStack;
+import de.markusbordihn.easymodelentities.api.data.client.EasyModelEntityRenderOptions;
 import de.markusbordihn.easymodelentities.client.render.EasyModelEntityRenderBackend;
 import de.markusbordihn.easymodelentities.client.render.EasyModelEntityRenderState;
 import de.markusbordihn.easymodelentities.runtime.EasyModelAnimationState;
@@ -55,6 +56,12 @@ public class EasyModelNPCRenderer<E extends PathfinderMob>
   public void extractRenderState(
       E entity, EasyModelEntityRenderState renderState, float partialTick) {
     super.extractRenderState(entity, renderState, partialTick);
+    renderState.easyModelRenderState = null;
+    renderState.renderOptions = EasyModelEntityRenderOptions.DEFAULT;
+    renderState.animationState = EasyModelAnimationState.AUTO;
+    renderState.limbSwing = 0.0f;
+    renderState.limbSwingAmount = 0.0f;
+    renderState.airborneAmount = 0.0f;
     if (!(entity instanceof EasyModelNPC easyModelNPC)) {
       return;
     }
@@ -68,6 +75,10 @@ public class EasyModelNPCRenderer<E extends PathfinderMob>
                 renderState.easyModelRenderState =
                     EasyModelEntityRenderBackend.resolveRenderState(contract),
             () -> log.debug("No EME contract for profile: {}", profileId));
+
+    renderState.renderOptions =
+        EasyModelEntityRenderOptions.DEFAULT.withPartAnimator(
+            EasyModelNPCPartAnimator.snapshot(easyModelNPC));
 
     renderState.entityYaw =
         entity instanceof LivingEntity le

--- a/reports/PROGRESS.md
+++ b/reports/PROGRESS.md
@@ -1,0 +1,60 @@
+# EasyNPC Advanced Rig Progress
+
+## Этап 0 — baseline и аудит EME pose rendering
+
+### Выполнено
+
+- Подтверждены ветки `26.1.2` и `1.20.1` для EasyNPC и Easy Model Entities.
+- Зафиксированы исходные commit SHA всех трёх репозиториев.
+- Подтверждена фактическая структура `core`, `config-ui`, `bundle` и loader-модулей.
+- Прослежен submit-node render pipeline Minecraft 26.1.2.
+- Подтверждена регрессия: submit-path EME всегда передавал `EasyModelPartAnimator.NONE`.
+- Подготовлен минимальный межрепозиторный patch для передачи render options через render state.
+- В EasyNPC восстановлено сопоставление EME bone name с существующим `ModelPartType`.
+- Animator получает immutable snapshot pose-данных на этапе `extractRenderState` и не читает entity в draw-call.
+- При повторном использовании render state очищаются model, animation и movement поля, чтобы исключить stale state.
+- Созданы commits: EME `132b2a8`, EasyNPC `9b36baa6`.
+
+### Изменённые файлы
+
+Easy Model Entities:
+
+- `Common/src/main/java/de/markusbordihn/easymodelentities/client/render/EasyModelEntityRenderState.java`
+- `Common/src/main/java/de/markusbordihn/easymodelentities/client/render/EasyModelEntityRenderBackend.java`
+- `Common/src/test/java/de/markusbordihn/easymodelentities/client/render/EasyModelEntityRenderBackendTest.java`
+
+EasyNPC:
+
+- `core/Common/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCPartAnimator.java`
+- `core/Common/src/test/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCPartAnimatorTest.java`
+- `core/Fabric/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCRenderer.java`
+- `core/Forge/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCRenderer.java`
+- `core/NeoForge/src/main/java/de/markusbordihn/easynpc/client/renderer/entity/easymodelentities/EasyModelNPCRenderer.java`
+
+### Архитектурные решения
+
+- Render options являются частью EME render state и потребляются существующим backend вместо жёстко заданного `NONE + ADD`.
+- EasyNPC сохраняет старую семантику additive pose поверх автоматической EME animation.
+- В render state передаётся snapshot готовых `EasyModelPartTransform`, а не ссылка на NPC или синхронизируемые maps.
+- Не вводятся dynamic bones, новый entity type или UI до проверки первого milestone.
+
+### Проверки
+
+- `git diff --check`: успешно для EasyNPC и EME.
+- Добавлены unit tests для default/custom render options.
+- Добавлены unit tests для canonical bone mapping, unknown bone fallback и snapshot isolation.
+- Baseline/patch Gradle build не выполнен по причине окружения: доступна только Java 17 вместо Java 25; Gradle wrapper 9.6.1 не может скачать distribution из-за сетевого ограничения.
+
+### Известные проблемы
+
+- Patch требует совместных совместимых версий EME и EasyNPC; EasyNPC нельзя собирать против старого бинарника EME 1.5.0 без нового поля render state.
+- Не выполнены client, dedicated server и in-game проверки.
+- Не проверены root transforms и GUI preview; первый patch восстанавливает только существующие именованные `ModelPartType` bones.
+
+### Следующий шаг
+
+1. Собрать EME на Java 25 и опубликовать в local Maven либо передать EasyNPC через `easy_model_entities_local_jar`.
+2. Собрать `core`, затем `config-ui`, затем `bundle`.
+3. Запустить Fabric client и проверить rotation/position/scale/visibility на стандартной EME humanoid-модели.
+4. Запустить dedicated Fabric server и multiplayer sync test.
+5. После зелёного milestone перейти к dynamic bone data.


### PR DESCRIPTION
## Summary

Restore EasyNPC pose transforms for Easy Model Entities render states.

## Why

EasyNPC's EME renderer path on Minecraft 26.1.2 no longer forwarded the fixed EasyNPC pose data into the EME submit renderer. This reintroduces a render-state-safe animator snapshot and documents the milestone.

## Validation

- Added unit coverage for canonical bone mapping, unknown bone fallback, and snapshot isolation.
- Patch was applied locally with `git am`.
- EasyNPC root baseline is still blocked locally by the Forge Mavenizer `extractServer` issue documented in `workspace/docs/BASELINE.md`.
